### PR TITLE
Auto detect local address

### DIFF
--- a/src/igd_async.rs
+++ b/src/igd_async.rs
@@ -1,6 +1,7 @@
 use futures::sync::oneshot;
 use igd::{self, AddAnyPortError, PortMappingProtocol, SearchError};
 use priv_prelude::*;
+use get_if_addrs::{self, IfAddr};
 
 use std::thread;
 
@@ -117,3 +118,46 @@ pub fn get_any_address(
     future::result(try()).flatten().into_boxed()
 }
 
+/// # Returns
+///
+/// Local IP address that is on the same subnet as gateway address. Returned address is always
+/// IPv4 because gateway always has IPv4 address as well.
+fn local_addr_to_gateway(gateway_addr: Ipv4Addr) -> io::Result<Ipv4Addr> {
+    let ifs = get_if_addrs::get_if_addrs()?;
+    for interface in ifs {
+        if let IfAddr::V4(addr) = interface.addr {
+            if in_same_subnet(addr.ip, gateway_addr, addr.netmask) {
+                return Ok(addr.ip);
+            }
+        }
+    }
+
+    Err(io::Error::new(io::ErrorKind::NotFound, "No local addresses to gateway"))
+}
+
+/// # Returns
+///
+/// `true` if given IP addresses are in the same subnet, `false` otherwise.
+fn in_same_subnet(addr1: Ipv4Addr, addr2: Ipv4Addr, subnet_mask: Ipv4Addr) -> bool {
+    addr1.octets().iter().zip(subnet_mask.octets().iter()).map(|(o1, o2)| o1 & o2)
+        .eq(addr2.octets().iter().zip(subnet_mask.octets().iter()).map(|(o1, o2)| o1 & o2))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod in_same_subnet {
+        use super::*;
+
+        #[test]
+        fn it_returns_true_when_given_addresses_are_in_same_subnet() {
+            assert!(in_same_subnet(ipv4!("192.168.1.1"), ipv4!("192.168.1.10"), ipv4!("255.255.255.0")));
+        }
+
+        #[test]
+        fn it_returns_false_when_given_addresses_are_not_in_same_subnet() {
+            assert!(!in_same_subnet(ipv4!("192.168.1.1"), ipv4!("172.10.0.5"), ipv4!("255.255.255.0")));
+        }
+    }
+}


### PR DESCRIPTION
Trying to bind to unspecified address would result in IGD error:
``
TcpListener::bind_public(&addr!("0.0.0.0:0"), &handle)
```
This PR fixes that: when gateway address is found, local interfaces are fetched with their addresses. Then the address is used to bind that's in the same subnet as gateway.