### PR TITLE
Fix port mapping address

### DIFF
--- a/src/igd_async.rs
+++ b/src/igd_async.rs
@@ -188,6 +188,19 @@ fn in_same_subnet(addr1: Ipv4Addr, addr2: Ipv4Addr, subnet_mask: Ipv4Addr) -> bo
 #[cfg(test)]
 mod test {
     use super::*;
+    use get_if_addrs::Ifv4Addr;
+
+    fn interface(addr: Ipv4Addr, netmask: Ipv4Addr) -> Interface {
+        let ipv4 = Ifv4Addr {
+            ip: addr,
+            netmask,
+            broadcast: None,
+        };
+        Interface {
+            name: "test-if".to_string(),
+            addr: IfAddr::V4(ipv4),
+        }
+    }
 
     mod in_same_subnet {
         use super::*;
@@ -200,6 +213,40 @@ mod test {
         #[test]
         fn it_returns_false_when_given_addresses_are_not_in_same_subnet() {
             assert!(!in_same_subnet(ipv4!("192.168.1.1"), ipv4!("172.10.0.5"), ipv4!("255.255.255.0")));
+        }
+    }
+
+    mod local_addr_to_gateway {
+        use super::*;
+
+        #[test]
+        fn it_returns_none_interfaces_list_is_empty() {
+            let local_addr = local_addr_to_gateway(Vec::new(), ipv4!("192.168.1.1"));
+
+            assert!(local_addr.is_none());
+        }
+
+        #[test]
+        fn it_returns_none_when_no_interface_is_in_the_same_subnet_as_gateway() {
+            let local_addr = local_addr_to_gateway(
+                vec![interface(ipv4!("172.17.0.1"), ipv4!("255.255.0.0"))],
+                ipv4!("192.168.1.1"),
+            );
+
+            assert!(local_addr.is_none());
+        }
+
+        #[test]
+        fn it_returns_ip_address_of_the_interface_that_is_in_the_same_subnet_as_gateway() {
+            let local_addr = local_addr_to_gateway(
+                vec![
+                    interface(ipv4!("172.17.0.1"), ipv4!("255.255.0.0")),
+                    interface(ipv4!("192.168.1.100"), ipv4!("255.255.255.0"))
+                ],
+                ipv4!("192.168.1.1"),
+            );
+
+            assert_eq!(unwrap!(local_addr), ipv4!("192.168.1.100"));
         }
     }
 }


### PR DESCRIPTION
If local address is specified (not `0.0.0.0`), then it is used to get public address mappings via IGD.
Before this PR, library would ignore local address parameter and act as if user always provided `0.0.0.0`.

Also added some more unit tests.